### PR TITLE
Find input bar by ID not working 

### DIFF
--- a/emoji.json
+++ b/emoji.json
@@ -1,0 +1,11 @@
+{
+	":laughing:" : ":-d", 
+	":neutral_face:" : ":-|", 
+	"stuck_out_tongue:" : ":-p", 
+	":heart:" : "<3", 
+	":simple_smile:" : ":-)", 
+	":worried:" : ":-(", 
+	":-1:" : "(n)", 
+	":thumbsup:" : "(y)", 
+	":wink:" : ";-)"
+}

--- a/whatsapp.py
+++ b/whatsapp.py
@@ -134,7 +134,7 @@ class WhatsApp:
     def get_last_seen(self, name, timeout=10):
         search = self.browser.find_element_by_id("input-chatlist-search")
         search.send_keys(name+Keys.ENTER)  # we will send the name to the input key box
-        last_seen_css_selector = ".chat-subtitle-text"
+        last_seen_css_selector = ".O90ur"
         start_time = dt.datetime.now()
         try:
             WebDriverWait(self.browser,self.timeout).until(EC.presence_of_element_located(


### PR DESCRIPTION
Like I mentioned in the "issues" section, I was unable to get the input search bar with the `browser.get_element_by_id` query. I guess maybe WhatsApp web was updated and therefore it changed its attributes. Since it now has no id attribute, I thought of using its XPath. 